### PR TITLE
Bootstrap tracer into examples

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Sarah Lim <sarah@sarahlim.com>"]
 
 [dependencies]
 parity-wasm = "0.31"
+lazy_static = "1.0.1"
 
 [dev-dependencies]
 parity-wasm = "0.31"

--- a/examples/function-calls/main.rs
+++ b/examples/function-calls/main.rs
@@ -1,9 +1,14 @@
+#[macro_use]
 extern crate wasm_trace;
 
 use wasm_trace::tracer::Tracer;
 
+tracer_dependencies!();
+tracer_bootstrap!();
+
 #[no_mangle]
 pub extern "C" fn double_subtract5_add1(x: i32) -> i32 {
+    println!("{}", double(x) + double(x));
     let result = double(x) + negate(5) + 1;
     return result;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,4 +5,7 @@ pub mod module;
 mod ring_buffer;
 pub mod tracer;
 
+#[allow(unused_imports)]
+#[macro_use]
+extern crate lazy_static;
 extern crate parity_wasm;


### PR DESCRIPTION
External Rust programs can now setup tracing using the `tracer_bootstrap!` macro in their crate root. This macro expands into the definitions for three exported functions:

- `__log_call`, which logs the index in the function index space of an invoked function;
- `__expose_tracer`, which returns a raw pointer to the `Tracer` accessible via JavaScript;
- `__expose_tracer_len`, which returns the current length of the `Tracer` buffer.

This PR alone doesn't perform any instrumentation, but including these functions will allow us to instrument the main binary with call instructions to the `__log_call` function later on.