### PR TITLE
Trace function return values

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ authors = ["Sarah Lim <sarah@sarahlim.com>"]
 [dependencies]
 parity-wasm = "0.31"
 lazy_static = "1.0.1"
+itertools = "0.7.8"
 
 [dev-dependencies]
 parity-wasm = "0.31"

--- a/README.md
+++ b/README.md
@@ -4,28 +4,108 @@
 
 Based on an [idea](https://gist.github.com/fitzgen/34073d61f2c358f2b35038fa263b74a3) by [Nick Fitzgerald](https://github.com/fitzgen) from Mozilla.
 
-## Current status
+## Current functionality
 
-List the instructions in each module function:
+Goal: P1 functionality by project handin.
 
+- Instrument functions
+  - [x] (P0) Instrument exported functions
+  - [ ] (P1) Instrument the whole function section, including standard library functions, *except* for the transitive closure of the functions called by the tracer
+  - [ ] Filter function names by regex
+- Calls
+  - [x] (P0) Log that a call happened
+  - [ ] (P2) Log arguments to calls
+  - [ ] (P3) Capture call frequency
+- Returns
+  - [x] (P0) Log that a return happened
+  - [x] (P1) Log returned value if `i32`
+  - [ ] (P1) Log returned value if wasm-supported type
+    - Instrumentation is done, but need to update JavaScript and tracer to support 64 bits.
+  - [ ] (P2) Log returned value if Rust type (via pointer)
+- UI/UX
+  - [x] (P0) Display function ids
+  - [ ] (P1) Display formatted names
+  - [x] (P0) Bootstrap the tracer using macros
+  - [ ] (P2) Bootstrap the tracer using `extern crate wasm_trace;` alone
+  - [ ] (P2) Allow users to specify ring buffer size
+  - [ ] (P3) Display histogram of call frequency
+
+## Usage
+
+Given the following Rust program:
+
+```rust
+#[macro_use]
+extern crate wasm_trace;
+
+use wasm_trace::tracer::Tracer;
+
+tracer_dependencies!();
+tracer_bootstrap!();
+
+#[no_mangle]
+pub extern "C" fn do_stuff(x: i32) -> i32 {
+    println!("{}", double(x) + double(x));
+    println!("{}", factorial(x as u32));
+    let result = double(x) + negate(5) + 1;
+    void();
+    return result;
+}
+
+#[no_mangle]
+pub fn double(x: i32) -> i32 {
+    return x * 2;
+}
+
+#[no_mangle]
+pub fn negate(x: i32) -> i32 {
+    return -1 * x;
+}
+
+#[no_mangle]
+pub fn void() {
+    println!("No return value here!");
+}
+
+#[no_mangle]
+pub fn factorial(n: u32) -> u32 {
+    if n == 1 || n == 0 {
+        1
+    } else {
+        n * factorial(n - 1)
+    }
+}
+```
+
+We can pass the `.wasm` binary to the program:
 ```sh
-> cd ~/git/wasm-trace/examples/function-calls
-> make
-# node ../bin/runWasm.js function-calls.wasm double_subtract5_add1 10
-Invoking exported function double_subtract5_add1 with arguments [ 10 ] ...
-Result of function call: 16
-Calls: Int32Array [  ]
-
-# cargo run function-calls.wasm
-    Finished dev [unoptimized + debuginfo] target(s) in 0.02s
-     Running `/Users/sarah/git/wasm-trace/target/debug/wasm-trace function-calls.wasm`
-Modified wasm module -> output.wasm
-
-# node ../bin/runWasm.js output.wasm double_subtract5_add1 10
-
-Invoking exported function double_subtract5_add1 with arguments [ 10 ] ...
-Result of function call: 16
-Calls: Int32Array [ 3, 4, 4, 4, 5 ]  # indices of called functions
+> cargo run function-calls.wasm
+```
+and evaluate the resulting `output.wasm` in Node. Specifically, we'll invoke `do_stuff(4)`:
+```sh
+> node ../bin/runWasm.js function-calls.wasm do_stuff 4
+Invoking exported function do_stuff with arguments [ 4 ] ...
+Result of function call: 4
+ call function 3
+  |  call function 4
+  |  return 8 from 4
+  |  call function 4
+  |  return 8 from 4
+  |  call function 5
+  |   |  call function 5
+  |   |   |  call function 5
+  |   |   |   |  call function 5
+  |   |   |   |  return 1 from 5
+  |   |   |  return 2 from 5
+  |   |  return 6 from 5
+  |  return 24 from 5
+  |  call function 4
+  |  return 8 from 4
+  |  call function 6
+  |  return -5 from 6
+  |  call function 7
+  |  return from 7
+ return 4 from 3
 ```
 
 ## Requirements

--- a/README.md
+++ b/README.md
@@ -9,35 +9,23 @@ Based on an [idea](https://gist.github.com/fitzgen/34073d61f2c358f2b35038fa263b7
 List the instructions in each module function:
 
 ```sh
-> cd ~/git/wasm-trace
-> cargo run test/function-names.wasm
-    Finished dev [unoptimized + debuginfo] target(s) in 0.06s
-     Running `target/debug/wasm-trace test/function-names.wasm`
-#0 _Z3addii : i32 i32 -> i32
-	GetLocal(1)
-	GetLocal(0)
-	I32Add
-	End
+> cd ~/git/wasm-trace/examples/function-calls
+> make
+# node ../bin/runWasm.js function-calls.wasm double_subtract5_add1 10
+Invoking exported function double_subtract5_add1 with arguments [ 10 ] ...
+Result of function call: 16
+Calls: Int32Array [  ]
 
-#1 _Z4add1i : i32 -> i32
-	GetLocal(0)
-	GetLocal(0)
-	Call(0)
-	GetLocal(0)
-	I32Add
-	End
+# cargo run function-calls.wasm
+    Finished dev [unoptimized + debuginfo] target(s) in 0.02s
+     Running `/Users/sarah/git/wasm-trace/target/debug/wasm-trace function-calls.wasm`
+Modified wasm module -> output.wasm
 
-#2 _Z5halved : f64 -> f64
-	GetLocal(0)
-	F64Const(4602678819172646912)
-	F64Mul
-	End
+# node ../bin/runWasm.js output.wasm double_subtract5_add1 10
 
-#3 _Z7doubleri : i32 -> i32
-	GetLocal(0)
-	I32Const(1)
-	I32Shl
-	End
+Invoking exported function double_subtract5_add1 with arguments [ 10 ] ...
+Result of function call: 16
+Calls: Int32Array [ 3, 4, 4, 4, 5 ]  # indices of called functions
 ```
 
 ## Requirements

--- a/examples/function-calls/Makefile
+++ b/examples/function-calls/Makefile
@@ -5,8 +5,8 @@ TARGET_DIR = ../../target/wasm32-unknown-unknown/debug/examples
 OUTPUT = output
 
 # wasm function name and arguments
-FUNCTION = double_subtract5_add1
-ARGS = 10
+FUNCTION = do_stuff
+ARGS = 4
 
 # Compile `test.rs` and execute in Node.
 all:

--- a/examples/function-calls/Makefile
+++ b/examples/function-calls/Makefile
@@ -1,6 +1,9 @@
 EXAMPLE = function-calls
 TARGET_DIR = ../../target/wasm32-unknown-unknown/debug/examples
 
+# Modified .wasm binary outputted by main.
+OUTPUT = output
+
 # wasm function name and arguments
 FUNCTION = double_subtract5_add1
 ARGS = 10
@@ -12,6 +15,8 @@ all:
 	make gc
 	make wat
 	make node
+	cargo run $(EXAMPLE).wasm
+	make node EXAMPLE=$(OUTPUT)
 
 clean:
 	rm -f *.wasm *.wat *.wast

--- a/examples/function-calls/main.rs
+++ b/examples/function-calls/main.rs
@@ -7,9 +7,11 @@ tracer_dependencies!();
 tracer_bootstrap!();
 
 #[no_mangle]
-pub extern "C" fn double_subtract5_add1(x: i32) -> i32 {
+pub extern "C" fn do_stuff(x: i32) -> i32 {
     println!("{}", double(x) + double(x));
+    println!("{}", factorial(x as u32));
     let result = double(x) + negate(5) + 1;
+    void();
     return result;
 }
 
@@ -23,6 +25,20 @@ pub fn negate(x: i32) -> i32 {
     return -1 * x;
 }
 
+#[no_mangle]
+pub fn void() {
+    println!("No return value here!");
+}
+
+#[no_mangle]
+pub fn factorial(n: u32) -> u32 {
+    if n == 1 || n == 0 {
+        1
+    } else {
+        n * factorial(n - 1)
+    }
+}
+
 pub fn main() {
-    println!("{}", double_subtract5_add1(10));
+    println!("{}", do_stuff(10));
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,3 +9,4 @@ pub mod tracer;
 #[macro_use]
 extern crate lazy_static;
 extern crate parity_wasm;
+extern crate itertools;

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,15 +7,16 @@ fn main() {
     let path = env::args().nth(1).expect("USAGE: cargo run module.wasm");
     match WasmModule::from_file(path) {
         Ok(mut module) => {
-            module.instrument_module();
-            if let Err(e) =  WasmModule::to_file("output.wasm", module) {
-                panic!(e);
-            } else {
-                println!("Modified wasm module -> output.wasm");
-            }           
+            if let Err(e) = module.instrument_module() {
+                panic!("Error instrumenting module: {}", e);
+            }
+            if let Err(e) = WasmModule::to_file("output.wasm", module) {
+                panic!("Error writing instrumented module: {}", e);
+            }
+            println!("Modified wasm module -> output.wasm");
         }
         Err(e) => {
-            panic!(e);
+            panic!("Error initializing module: {}", e);
         }
     }
 }

--- a/src/module.rs
+++ b/src/module.rs
@@ -133,12 +133,6 @@ impl WasmModule {
             return Err(Error::Other("Could not find tracing instructions"));
         }
 
-        for (i, f) in self.function_bodies().iter().enumerate() {
-            if i < 7 {
-                println!("\n{} before\n{:?}", i, f.code());
-            }
-        }
-
         let mut working = CodeSection::with_bodies(self.function_bodies().to_vec());
         self.add_tracing_instructions(logger.unwrap(), &mut working)?;
 
@@ -146,12 +140,6 @@ impl WasmModule {
             *current_section = working;
         } else {
             return Err(Error::Other("Could not replace code section"));
-        }
-
-        for (i, f) in self.function_bodies().iter().enumerate() {
-            if i < 7 {
-                println!("\n{}\n{:?}", i, f.code());
-            }
         }
 
         return Ok(());

--- a/src/tracer.rs
+++ b/src/tracer.rs
@@ -4,20 +4,31 @@ pub static LOG_CALL: &str = "__log_call";
 pub static EXPOSE_TRACER: &str = "__expose_tracer";
 pub static EXPOSE_TRACER_LEN: &str = "__expose_tracer_len";
 
+static RING_BUFFER_ENTRIES: usize = 1024;
+
+#[repr(i32)]
+#[derive(Debug)]
+pub enum EntryKind {
+    FunctionCall = 0,
+    FunctionReturnVoid = 1,
+    FunctionReturnValue = 2,
+}
+
 /// Wrapper around the ring buffer for recording function calls.
 #[derive(Debug)]
-pub struct Tracer(RingBuffer<u32>);
+pub struct Tracer(RingBuffer<i32>);
 
 impl Tracer {
     pub fn new() -> Self {
-        Tracer(RingBuffer::new(1024))
+        Tracer(RingBuffer::new(RING_BUFFER_ENTRIES * 2))
     }
 
-    pub fn log(&mut self, data: u32) {
+    pub fn log(&mut self, kind: i32, data: i32) {
+        self.0.enqueue(kind as i32);
         self.0.enqueue(data);
     }
 
-    pub fn as_ptr(&self) -> *const u32 {
+    pub fn as_ptr(&self) -> *const i32 {
         self.0.as_slice().as_ptr()
     }
 
@@ -47,13 +58,13 @@ macro_rules! tracer_bootstrap {
 
         #[allow(private_no_mangle_fns)]
         #[no_mangle]
-        pub fn __log_call(id: u32) {
-            TRACER.lock().unwrap().log(id);
+        pub fn __log_call(id: i32, data: i32) {
+            TRACER.lock().unwrap().log(id, data);
         }
 
         #[allow(private_no_mangle_fns)]
         #[no_mangle]
-        pub fn __expose_tracer() -> *const u32 {
+        pub fn __expose_tracer() -> *const i32 {
             TRACER.lock().unwrap().as_ptr()
         }
 
@@ -67,20 +78,28 @@ macro_rules! tracer_bootstrap {
 
 #[cfg(test)]
 mod test_tracer {
-    use super::Tracer;
+    use itertools::Itertools;
+    use super::{Tracer, EntryKind};
 
     #[test]
     fn get_ptr() {
         let mut tracer = Tracer::new();
-        let values: [u32; 3] = [4, 1, 2];
-        for &x in values.iter() {
-            tracer.log(x);
+        let kinds = vec![EntryKind::FunctionCall as i32,
+                         EntryKind::FunctionCall as i32,
+                         EntryKind::FunctionCall as i32];
+        let values = vec![4, 1, 2];
+        for (&kind, &x) in kinds.clone().iter().zip(values.clone().iter()) {
+            tracer.log(kind, x);
         }
+
         let ptr = tracer.as_ptr();
         let len = tracer.len();
+        let mut expected_values = kinds.iter().interleave(values.iter());
+
         unsafe {
             for i in 0..len {
-                assert_eq!(*ptr.offset(i as isize), values[i]);
+                let &expected = expected_values.next().unwrap();
+                assert_eq!(*ptr.offset(i as isize), expected);
             }
         }
     }

--- a/src/tracer.rs
+++ b/src/tracer.rs
@@ -4,7 +4,7 @@ pub static LOG_CALL: &str = "__log_call";
 pub static EXPOSE_TRACER: &str = "__expose_tracer";
 pub static EXPOSE_TRACER_LEN: &str = "__expose_tracer_len";
 
-static RING_BUFFER_ENTRIES: usize = 1024;
+static TRACER_LOG_ENTRIES: usize = 1024;
 
 #[repr(i32)]
 #[derive(Debug)]
@@ -20,7 +20,7 @@ pub struct Tracer(RingBuffer<i32>);
 
 impl Tracer {
     pub fn new() -> Self {
-        Tracer(RingBuffer::new(RING_BUFFER_ENTRIES * 2))
+        Tracer(RingBuffer::new(TRACER_LOG_ENTRIES * 2))
     }
 
     pub fn log(&mut self, kind: i32, data: i32) {


### PR DESCRIPTION
This PR ties together the `Tracer` interface with prologue/epilogue instrumentation. Specifically, we can now log:

- Function calls (by id, not yet name)
- Return values, from `return` and `end` instructions

One major change in the instrumentation strategy: previously, we were only adding epilogue instructions in the `n - 1`th position of a function body. This approach didn't capture returning from the middle of the function.

Now, we check for `return` instructions in the middle of the function. If the function is non-void, we create a new local `$my_local` with the return type, and insert
```wasm
tee_local $my_local   ; copy the top of the stack into $my_local without popping
i32.const 2           ; enum variant corresponding to a non-void return
get_local $my_local   ; push the contents of $my_local onto the stack
call $log_ring_buffer ; call the log function, popping the previous two arguments off the stack
```
before the `return`.